### PR TITLE
Fix fetch only once

### DIFF
--- a/src/main/java/com/fzi/externalcontrol/impl/ExternalControlInstallationNodeContribution.java
+++ b/src/main/java/com/fzi/externalcontrol/impl/ExternalControlInstallationNodeContribution.java
@@ -65,7 +65,8 @@ public class ExternalControlInstallationNodeContribution implements Installation
 
   @Override
   public void generateScript(ScriptWriter writer) {
-    
+    // Make sure the program gets requested at least once
+    urScriptProgram = "";
   }
 
   // IP helper functions

--- a/src/main/java/com/fzi/externalcontrol/impl/RequestProgram.java
+++ b/src/main/java/com/fzi/externalcontrol/impl/RequestProgram.java
@@ -56,6 +56,9 @@ public class RequestProgram {
       // 5 second timeout (make configurable?)
       int timeout = 5*1000;
       socket.connect(new InetSocketAddress(this.hostIp, this.portNr), timeout);
+      System.out.println("hostIp is: " + this.hostIp);
+      System.out.println("portNr is: " + this.portNr);
+
 
       if (socket.isConnected()) {
         // output stream creation
@@ -80,7 +83,7 @@ public class RequestProgram {
       }
       socket.close();
     } catch (IOException e) {
-      result = String.format("popup(\"The connection to the remote PC could not be established. Reason: %s\","
+      result = String.format("popup(\"The connection to the remote PC at " + this.hostIp + ":" + this.portNr + " could not be established. Reason: %s\","
           + "\"Receive program failed\", False, True, blocking=True)\n"
           + "sync()", e.getMessage());
     }


### PR DESCRIPTION
With the changes introduced in v1.0.3 the code was only fetched from the remote machine on the very first try after the robot has been booted. If that failed (e.g. because the driver was not running), one had to reboot the robot before being able to fetch the code.