### PR TITLE
Remove the possibility to misunderstand that you NEED this URCap to control the robot from remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# URcaps external control
-Package for external control of a UR robot. It supports UR3, UR5 and UR10 of CB3 as well as the e-series.
+# URCaps External Control
+The External Control URCap is the user interface for the Universal Robots [ROS](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver), [ROS2](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver) and [Isaac SDK](https://github.com/UniversalRobots/Universal_Robots_Isaac_Driver) driver, as well as the [Universal Robots Client Library](https://github.com/UniversalRobots/Universal_Robots_Client_Library]) used by the drivers.
 
-## prerequisites
+It supports the Universal Robots CB3 and e-Series robots.
+
+## Prerequisites
 As this URCap is using swing to implement the user interface, the URCap library in version 1.3.0 or
 higher is required. Therefore the minimal PolyScope versions are 3.7 and 5.1.
 
-To enable external control of a UR robot from a remote PC, this URcap must be installed on the UR robot and the ur\_rtde\_driver has to be installed on the remote PC. 
-
-## usage
+## Usage
 * In the _Installation_ tab of Polyscope:
 	* Adjust the IP address of your robot in the _Installation_ tab of Polyscope (this step might be unnecessary in simulation). 
 * On the remote PC:


### PR DESCRIPTION
Remove the possibility to misunderstand that you NEED this URCap to control the robot from remote. 
Instead emphasize that this is the UI for the Drivers.