### PR TITLE
Adding Simple external control server example

### DIFF
--- a/examples/simple_external_control_server/Readme.md
+++ b/examples/simple_external_control_server/Readme.md
@@ -1,0 +1,12 @@
+# Simple External Control Server example
+This simple server, serves the External Control with URScript provided by a file
+
+Example of use:
+```bash
+python3 simple_external_control_server.py -p 50002 hello_world.script
+```
+
+To install and use the URCap external control, follow the instructions from the ROS Driver for [e-Series](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/blob/master/ur_robot_driver/doc/install_urcap_e_series.md)
+or for [cb3-Series](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/blob/master/ur_robot_driver/doc/install_urcap_cb3.md).
+
+Once you play the program on a robot, a popup with the message "Hello World" should appear.

--- a/examples/simple_external_control_server/hello_world.script
+++ b/examples/simple_external_control_server/hello_world.script
@@ -1,0 +1,1 @@
+popup("Hello world")

--- a/examples/simple_external_control_server/simple_external_control_server.py
+++ b/examples/simple_external_control_server/simple_external_control_server.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# -- BEGIN LICENSE BLOCK ----------------------------------------------
+# Copyright 2022 Universal Robots A/S
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -- END LICENSE BLOCK ------------------------------------------------
+
+# A simple python 3 server to test the External Control URCap
+# The server answer request from the URCap with the context of the given file
+
+import socket
+import socketserver
+import threading
+import argparse
+
+parser = argparse.ArgumentParser(description='Simple External Control server')
+parser.add_argument(
+    "file", type=str, help="Path to the UR script file, which will be send to the robot")
+parser.add_argument("-p", "--port", type=int,
+                    default=50002, help="Port number to use")
+
+args = parser.parse_args()
+
+
+class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+class FileHandler(socketserver.StreamRequestHandler):
+    def handle(self):
+        client = f'{self.client_address} on {threading.currentThread().getName()}'
+        print(f'Connected: {client}')
+        file = open(args.file, "r")
+        while True:
+            data = file.read()
+
+            print(data)
+            if not data:
+                break
+            self.wfile.write(data.encode('utf-8'))
+        print(f'Closed: {client}')
+
+
+with ThreadedTCPServer(('', args.port), FileHandler) as server:
+    print(f'The Simple External Control server is running on port', args.port)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+    server.server_close()


### PR DESCRIPTION
Adding a python3 server script that can be used to serve the URCap, as mentioned in #21 
